### PR TITLE
Fixed Readme spacing (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Version: 1.0.4
   
   To install the libsodium PHP extension:
   
-	pecl install libsodium
+	    pecl install libsodium
   
   Then add the following line to your php.ini file:
   
-	extension=libsodium.so
+	    extension=libsodium.so
 
 If you want to check whether your server meets the requirements and everything is configured properly you can execute ```threema-msgapi-tool.php``` without any parameters on the console or point your browser to the location where it is saved on your server. 
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Version: 1.0.4
   
   To install the libsodium PHP extension:
   
-	    pecl install libsodium
+	  pecl install libsodium
   
   Then add the following line to your php.ini file:
   
-	    extension=libsodium.so
+	  extension=libsodium.so
 
 If you want to check whether your server meets the requirements and everything is configured properly you can execute ```threema-msgapi-tool.php``` without any parameters on the console or point your browser to the location where it is saved on your server. 
 


### PR DESCRIPTION
Readded spaces to add code style display.

Unfortunately I noticed in https://github.com/threema-ch/threema-msgapi-sdk-php/pull/4 the lines for installing libsodium did not had a code style any more. Now they have one again.
