### PR TITLE
Minor changes for TLS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ $settings = new ConnectionSettings(
     null, //the host to be use, set to null for default (recommend)
     [
         'forceHttps' => true, //set to true to force HTTPS, default: false
-        'tslVersion' => '1.2', //set the version of TLS to be used, default: null
-        'tslCipher' => 'ECDHE-RSA-AES128-GCM-SHA256' //choose a cipher or a list of ciphers, default: null
+        'tlsVersion' => '1.2', //set the version of TLS to be used, default: null
+        'tlsCipher' => 'ECDHE-RSA-AES128-GCM-SHA256' //choose a cipher or a list of ciphers, default: null
     ]
 );
 

--- a/source/Threema/MsgApi/Connection.php
+++ b/source/Threema/MsgApi/Connection.php
@@ -157,13 +157,13 @@ class Connection
 			CURLOPT_RETURNTRANSFER => true
 		);
 
-		// no progress
+		//no progress
 		if (null !== $progress) {
 			$options[CURLOPT_NOPROGRESS] = false;
 			$options[CURLOPT_PROGRESSFUNCTION] = $progress;
 		}
 
-		// tls settings
+		//tls settings
 
 		if (true === $this->setting->getTlsOption(ConnectionSettings::tlsOptionForceHttps, false)) {
 			// limit allowed protocols to HTTPS

--- a/source/Threema/MsgApi/ConnectionSettings.php
+++ b/source/Threema/MsgApi/ConnectionSettings.php
@@ -36,8 +36,8 @@ class ConnectionSettings
 	/**
 	 * @param string $threemaId valid threema id (8chars)
 	 * @param string $secret secret
-	 * @param string $host server url
-	 * @param array|null $tlsOptions
+	 * @param string|null $host server url
+	 * @param array|null $tlsOptions advanced TLS options
 	 */
 	public function __construct($threemaId, $secret, $host = null, array $tlsOptions = null) {
 		$this->threemaId = $threemaId;


### PR DESCRIPTION
Just some small fixes after merging https://github.com/threema-ch/threema-msgapi-sdk-php/pull/17 and your corrections in https://github.com/threema-ch/threema-msgapi-sdk-php/commit/44073c2d809cfbdcec90475b40759a8663c68ae9.

Alghough I have to say that I consider [this](https://github.com/threema-ch/threema-msgapi-sdk-php/blob/master/source/Threema/MsgApi/Connection.php#L172) e.g. a bit confusing as it's at the first look quite strange to see an assignment operator in a if expression.
Additionally constants should be written in capital letters, which is also 'blamed' by [Sensiolabs Insights](https://insight.sensiolabs.com/projects/0d2aa31f-7a59-44a1-b8cf-62a0a264eab5/analyses/22?status=violations#340056788) (see https://github.com/threema-ch/threema-msgapi-sdk-php/issues/7)..
